### PR TITLE
Implement `ToBitmap()` without `System.Drawing.Common`

### DIFF
--- a/QrCodeGeneratorTest/QrCodeBitmapTest.cs
+++ b/QrCodeGeneratorTest/QrCodeBitmapTest.cs
@@ -1,0 +1,28 @@
+using System;
+using Xunit;
+
+namespace Net.Codecrete.QrCodeGenerator.Test;
+
+public class QrCodeBitmapTest
+{
+    [Theory]
+    [InlineData("https://some-weird-test-site.site?whatever=test&test=123&qrcodes=true", 0, "Qk1GAQAAAAAAAD4AAAAoAAAAIQAAACEAAAABAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP///wABGCx2gAAAAH1eebmAAAAARXqcGoAAAABFbeAjgAAAAEUxPQaAAAAAfZ54cIAAAAABHHRSgAAAAP81xHUAAAAARaA3AwAAAABerNA5gAAAAFFkeZqAAAAAPnniygAAAABkUj3mgAAAAE6V0/WAAAAAELqxOoAAAADG9cBaAAAAABVIFDaAAAAAP23B3YAAAAAMZHv2gAAAALK/5p4AAAAAlBC9o4AAAACSd3A9gAAAAK1cl9qAAAAAgldg3AAAAAAEKDQqgAAAAP+M63+AAAAAAVVVQAAAAAB9IH3fAAAAAEW7TtEAAAAARRAn0QAAAABF9dHRAAAAAH1a8V8AAAAAAddiwAAAAAA=")]
+    public void ToBitmap_CreatesValidBitmap(string stubText, int stubEccOrdinal, string expectedBitmapBase64)
+    {
+        var stubEcc = stubEccOrdinal switch
+        {
+            0 => QrCode.Ecc.Low,
+            1 => QrCode.Ecc.Medium,
+            2 => QrCode.Ecc.Quartile,
+            3 => QrCode.Ecc.High,
+            _ => throw new ArgumentOutOfRangeException(nameof(stubEccOrdinal), stubEccOrdinal, string.Empty)
+        };
+
+        var qrCode = QrCode.EncodeText(stubText, stubEcc);
+
+        var actualBitmap = qrCode.ToMonochromeBitmap();
+        var actualBase64 = Convert.ToBase64String(actualBitmap);
+        
+        Assert.Equal(expectedBitmapBase64, actualBase64);
+    }
+}


### PR DESCRIPTION
First of all, thanks for an awesome library!

This is an implementation for writing `QrCode._modules` data into a monochrome (1 bpp) bitmap. It might not be the most optimal implementation ever, but it works. No dependencies required and it's cross-platform.

I think it's obvious that I don't really know how to properly test it apart from writing to a file and reading it with an image viewer and then scanning the QR code, just to be sure.

This is the bitmap generated using `https://some-weird-test-site.site?whatever=test&test=123&qrcodes=true` as the QR code input:
![test](https://user-images.githubusercontent.com/33006333/212377965-4206302f-0f25-4670-abe9-5c65a12ff7c0.png)

GitHub won't let me upload a BMP so this is a PNG and it's super tiny. Obviously, it's the same size as the QR code so care must be taken to ensure nearest neighbor scaling for a nice upscaled image.

Again, thanks for the library!
Cheers!