### PR TITLE
Enable trimming

### DIFF
--- a/QrCodeGenerator/QrCodeGenerator.csproj
+++ b/QrCodeGenerator/QrCodeGenerator.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
     <RootNamespace>Net.Codecrete.QrCodeGenerator</RootNamespace>
     <PackageId>Net.Codecrete.QrCodeGenerator</PackageId>
     <Version>2.0.4</Version>


### PR DESCRIPTION
Enable trimming. Using multitargeting since [.NET Standard doesn't support trimming](https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/trimming-unsupported-targetframework).