### PR TITLE
Add .NET 8 / .NET 10 as TFMs

### DIFF
--- a/QrCodeGenerator/QrCodeGenerator.csproj
+++ b/QrCodeGenerator/QrCodeGenerator.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-    <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
+    <IsTrimmable Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net10.0'">true</IsTrimmable>
     <RootNamespace>Net.Codecrete.QrCodeGenerator</RootNamespace>
     <PackageId>Net.Codecrete.QrCodeGenerator</PackageId>
     <Version>2.1.0</Version>

--- a/QrCodeGenerator/QrCodeGenerator.csproj
+++ b/QrCodeGenerator/QrCodeGenerator.csproj
@@ -70,7 +70,7 @@ Optional advanced features:
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.102" PrivateAssets="All"/>
   </ItemGroup>
 
   <Target Name="ValidateNuGetPackage" AfterTargets="Pack">

--- a/QrCodeGeneratorTest/QrCodeGeneratorTest.csproj
+++ b/QrCodeGeneratorTest/QrCodeGeneratorTest.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">net481;$(TargetFrameworks)</TargetFrameworks>
     <RootNamespace>Net.Codecrete.QrCodeGenerator.Test</RootNamespace>
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <SuppressTfmSupportBuildErrors>true</SuppressTfmSupportBuildErrors>
     <TestResultsFile>$([System.IO.Path]::Combine($(MSBuildThisFileDirectory),'..','TestResults-$(MSBuildProjectName)-$(TargetFramework).html'))</TestResultsFile>
   </PropertyGroup>
 
@@ -17,11 +17,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Verify.ImageMagick" Version="3.8.1" />
-    <PackageReference Include="Verify.Xunit" Version="31.9.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Verify.ImageMagick" Version="3.8.3" />
+    <PackageReference Include="Verify.Xunit" Version="31.9.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/QrCodeGeneratorTest/QrCodeGeneratorTest.csproj
+++ b/QrCodeGeneratorTest/QrCodeGeneratorTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">net481;$(TargetFrameworks)</TargetFrameworks>
     <RootNamespace>Net.Codecrete.QrCodeGenerator.Test</RootNamespace>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>


### PR DESCRIPTION
Hello,

this Library is featured in the Microsoft Documentation about [ASP.NET Core Identity Multi-Factor Authentication](https://learn.microsoft.com/en-us/aspnet/core/blazor/security/qrcodes-for-authenticator-apps?view=aspnetcore-10.0).

Then I looked over the repo and saw that the package is mainly available and compiled for .NET 6. In the state of it being EoL since November 2024 I took the little effort to upgrade the TFMs to support .NET 8 and .NET 10 too. I also upgraded the NuGet packages so they're being available in the newest versions.

All tests are passing despite the .NET 6 ones won't even run, it just discovers no test available strangely.
<img width="1506" height="593" alt="image" src="https://github.com/user-attachments/assets/c47bb6dd-3c64-4ed0-a4a5-859b642f5b76" />


### Open Question
Since all of the Demo projects currently build as .NET 8 compatible my suggestion would be to throw out .NET 6 completely and only support the current LTS versions. This also allows to use newer Language Features like Collection Expressions etc.